### PR TITLE
Improve timezone comparison UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,12 +44,21 @@ def difference(tz_a: str, tz_b: str, at: datetime | None = None):
     sign = 1 if delta >= 0 else -1
     h = int(abs(delta))
     m = int(round((abs(delta) - h) * 60))
+    pretty_abs = f"{h}h {m:02d}m"
+    direction = "ahead of" if sign > 0 else "behind" if sign < 0 else "the same time as"
+    if sign == 0:
+        description = f"{tz_b} is the same time as {tz_a}"
+    else:
+        description = f"{tz_b} is {pretty_abs} {direction} {tz_a}"
     return {
         "a": a,
         "b": b,
         "hours": sign * h,
         "minutes": sign * m,
-        "pretty": f"{('+' if sign>0 else '-')}{h:01d}h {m:02d}m"
+        "pretty": f"{('+' if sign>0 else '-')}{h:01d}h {m:02d}m",
+        "direction": direction,
+        "pretty_abs": pretty_abs,
+        "description": description,
     }
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -28,3 +28,20 @@
     }
   });
 })();
+
+// Swap selected time zones and submit the form
+(function swapZones() {
+  const btn = document.getElementById('swap');
+  const form = document.getElementById('compare-form');
+  if (!btn || !form) return;
+  btn.addEventListener('click', () => {
+    const a = document.getElementById('my_tz');
+    const b = document.getElementById('other_tz');
+    if (a && b) {
+      const tmp = a.value;
+      a.value = b.value;
+      b.value = tmp;
+      form.submit();
+    }
+  });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,79 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f7fa;
+  color: #333;
+  margin: 0;
+}
+
+header {
+  background: #004d99;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+
+.controls, .result, .table-section {
+  max-width: 900px;
+  margin: 1rem auto;
+  padding: 0 1rem;
+}
+
+.control {
+  margin-bottom: 0.5rem;
+}
+
+.control.buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cards {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.card.arrow {
+  background: none;
+  box-shadow: none;
+  font-size: 2rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th, .table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+#search {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.delta {
+  text-align: center;
+  font-size: 1.1rem;
+  margin-top: 0.5rem;
+}
+
+footer {
+  text-align: center;
+  margin: 2rem 0;
+  font-size: 0.9rem;
+  color: #666;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,9 +32,12 @@
         </select>
       </div>
 
-      <button type="submit">Compare</button>
+      <div class="control buttons">
+        <button type="button" id="swap">Swap</button>
+        <button type="submit">Compare</button>
+      </div>
     </form>
-    <small class="hint">Tip: Your browser’s time zone will auto-fill on load; you can still pick any zone.</small>
+    <small class="hint">Tip: Your browser's time zone will auto-fill on load; you can still pick any zone.</small>
   </section>
 
   <section class="result">
@@ -52,7 +55,7 @@
         <p class="offset">UTC {{ diff.b.strftime('%z')[:3] }}:{{ diff.b.strftime('%z')[3:5] }}</p>
       </div>
     </div>
-    <p class="delta">Difference: <strong>{{ diff.pretty }}</strong></p>
+    <p class="delta">{{ diff.description }} ({{ diff.pretty }})</p>
   </section>
 
   <section class="table-section">


### PR DESCRIPTION
## Summary
- Display human-friendly messages describing time differences
- Add swap button and styling for easier timezone comparison
- Include basic CSS for clearer layout

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee8c1f5ac8328b6d23ee495726a5a