### PR TITLE
Fix timezone difference calculation and add timezone code search

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -59,6 +59,12 @@ header {
   text-align: left;
 }
 
+.tz-abbr {
+  color: #666;
+  font-size: 0.8em;
+  margin-left: 0.25rem;
+}
+
 #search {
   width: 100%;
   padding: 0.5rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,7 +82,7 @@
 
   <section class="table-section">
     <h2>All time zones</h2>
-    <input id="search" type="search" placeholder="Search time zones... (e.g., Europe/ , America/ , *UTC*)" />
+    <input id="search" type="search" placeholder="Search zones or codes (e.g., UTC, GMT, Europe/)" />
     <table class="table" id="zones-table">
       <thead>
         <tr>
@@ -94,7 +94,7 @@
       <tbody>
         {% for r in all_rows %}
         <tr>
-          <td>{{ r.zone }}</td>
+          <td>{{ r.zone }} <small class="tz-abbr">{{ r.abbr }}</small></td>
           <td>{{ r.now.strftime('%Y-%m-%d %H:%M') }}</td>
           <td>{{ r.offset }}</td>
         </tr>


### PR DESCRIPTION
## Summary
- correct timezone difference calculation using UTC offsets
- display timezone abbreviations and allow search by codes like GMT or UTC
- style timezone code display

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'...`
- `python - <<'PY'` (Flask test client)


------
https://chatgpt.com/codex/tasks/task_e_689eeb32a6c4832880ae89f3f9bd01f2