### PR TITLE
Use time codes and add dark mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,22 +1,46 @@
 from __future__ import annotations
 from flask import Flask, render_template, request
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo, available_timezones
+from datetime import datetime, timedelta, timezone
+
+# Mapping of short time zone codes to fixed UTC offsets
+CODE_TO_TZ: dict[str, timezone] = {}
+
+
+def _build_code_map() -> None:
+    """Populate CODE_TO_TZ with common offset-based codes."""
+    for h in range(-12, 15):  # UTC-12 .. UTC+14
+        if h == 0:
+            continue
+        name = f"UTC{h:+03d}:00"
+        CODE_TO_TZ[name] = timezone(timedelta(hours=h), name)
+    # Common aliases
+    CODE_TO_TZ["UTC"] = timezone.utc
+    CODE_TO_TZ["GMT"] = timezone.utc
+    CODE_TO_TZ["CET"] = timezone(timedelta(hours=1), "CET")
+    CODE_TO_TZ["CEST"] = timezone(timedelta(hours=2), "CEST")
+    CODE_TO_TZ["EST"] = timezone(timedelta(hours=-5), "EST")
+    CODE_TO_TZ["EDT"] = timezone(timedelta(hours=-4), "EDT")
+    CODE_TO_TZ["CST"] = timezone(timedelta(hours=-6), "CST")
+    CODE_TO_TZ["CDT"] = timezone(timedelta(hours=-5), "CDT")
+    CODE_TO_TZ["MST"] = timezone(timedelta(hours=-7), "MST")
+    CODE_TO_TZ["MDT"] = timezone(timedelta(hours=-6), "MDT")
+    CODE_TO_TZ["PST"] = timezone(timedelta(hours=-8), "PST")
+    CODE_TO_TZ["PDT"] = timezone(timedelta(hours=-7), "PDT")
+    CODE_TO_TZ["BST"] = timezone(timedelta(hours=1), "BST")
+    CODE_TO_TZ["IST"] = timezone(timedelta(hours=5, minutes=30), "IST")
+
+
+_build_code_map()
+
+ZONES = sorted(CODE_TO_TZ.keys())
 
 app = Flask(__name__)
 
-# Build a sorted list of IANA zones; put "Etc/UTC" at top and group by area
-ALL_ZONES = sorted(available_timezones())
-if "Etc/UTC" in ALL_ZONES:
-    ALL_ZONES.remove("Etc/UTC")
-ZONES = ["Etc/UTC"] + ALL_ZONES
-
-
 def now_utc():
-    return datetime.now(tz=ZoneInfo("UTC"))
+    return datetime.now(tz=timezone.utc)
 
 
-def fmt_offset(tz: ZoneInfo) -> str:
+def fmt_offset(tz: timezone) -> str:
     # Returns a pretty UTC offset like "+02:00" or "-05:30"
     offset = datetime.now(tz).utcoffset() or timedelta()
     total_minutes = int(offset.total_seconds() // 60)
@@ -26,7 +50,7 @@ def fmt_offset(tz: ZoneInfo) -> str:
 
 
 def current_time_in_zone(tz_name: str):
-    tz = ZoneInfo(tz_name)
+    tz = CODE_TO_TZ[tz_name]
     dt = now_utc().astimezone(tz)
     return {
         "zone": tz_name,
@@ -38,8 +62,8 @@ def current_time_in_zone(tz_name: str):
 
 def difference(tz_a: str, tz_b: str, at: datetime | None = None):
     at = at or now_utc()
-    a = at.astimezone(ZoneInfo(tz_a))
-    b = at.astimezone(ZoneInfo(tz_b))
+    a = at.astimezone(CODE_TO_TZ[tz_a])
+    b = at.astimezone(CODE_TO_TZ[tz_b])
     # Compare the UTC offsets to determine the difference between zones
     offset_a = a.utcoffset() or timedelta()
     offset_b = b.utcoffset() or timedelta()
@@ -70,7 +94,7 @@ def difference(tz_a: str, tz_b: str, at: datetime | None = None):
 def index():
     # Optional query params: my_tz, other_tz
     my_tz = request.args.get("my_tz") or "UTC"
-    other_tz = request.args.get("other_tz") or "Europe/Stockholm"
+    other_tz = request.args.get("other_tz") or "UTC+01:00"
 
     # Build quick comparison and a small conversion table
     conv_base = now_utc()
@@ -87,8 +111,8 @@ def index():
 
     conversion = []
     for label, base in common_slots:
-        a = base.astimezone(ZoneInfo(my_tz))
-        b = base.astimezone(ZoneInfo(other_tz))
+        a = base.astimezone(CODE_TO_TZ[my_tz])
+        b = base.astimezone(CODE_TO_TZ[other_tz])
         conversion.append({
             "label": label,
             "a": a,

--- a/static/app.js
+++ b/static/app.js
@@ -1,14 +1,17 @@
-// Auto-detect browser timezone and set the "Your timezone" dropdown on first load.
+// Auto-detect browser offset and set the dropdown on first load.
 (function initAutoDetect() {
   try {
-    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const url = new URL(window.location.href);
-    if (!url.searchParams.get('my_tz') && detected) {
-      // Only redirect once; add my_tz while preserving other params
-      url.searchParams.set('my_tz', detected);
+    if (!url.searchParams.get('my_tz')) {
+      const offset = -new Date().getTimezoneOffset(); // minutes east of UTC
+      const sign = offset >= 0 ? '+' : '-';
+      const abs = Math.abs(offset);
+      const h = String(Math.floor(abs / 60)).padStart(2, '0');
+      const m = String(abs % 60).padStart(2, '0');
+      const code = offset === 0 ? 'UTC' : `UTC${sign}${h}:${m}`;
+      url.searchParams.set('my_tz', code);
       if (!url.searchParams.get('other_tz')) {
-        // default to UTC if user is already UTC, else compare with UTC for clarity
-        url.searchParams.set('other_tz', detected === 'Etc/UTC' ? 'Europe/Stockholm' : 'Etc/UTC');
+        url.searchParams.set('other_tz', code === 'UTC' ? 'UTC+01:00' : 'UTC');
       }
       window.location.replace(url.toString());
     }

--- a/static/style.css
+++ b/static/style.css
@@ -1,13 +1,13 @@
 body {
-  font-family: Arial, sans-serif;
-  background: #f5f7fa;
-  color: #333;
+  font-family: system-ui, sans-serif;
+  background: #121212;
+  color: #e0e0e0;
   margin: 0;
 }
 
 header {
-  background: #004d99;
-  color: #fff;
+  background: #1f1f1f;
+  color: #e0e0e0;
   padding: 1rem;
   text-align: center;
 }
@@ -36,10 +36,10 @@ header {
 }
 
 .card {
-  background: #fff;
+  background: #1e1e1e;
   padding: 1rem;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
 }
 
 .card.arrow {
@@ -48,13 +48,14 @@ header {
   font-size: 2rem;
 }
 
+
 .table {
   width: 100%;
   border-collapse: collapse;
 }
 
 .table th, .table td {
-  border: 1px solid #ddd;
+  border: 1px solid #333;
   padding: 0.5rem;
   text-align: left;
 }
@@ -69,6 +70,16 @@ header {
   width: 100%;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  background: #2a2a2a;
+  color: #e0e0e0;
+  border: 1px solid #444;
+}
+
+select, button {
+  background: #2a2a2a;
+  color: #e0e0e0;
+  border: 1px solid #444;
+  padding: 0.4rem;
 }
 
 .delta {
@@ -81,5 +92,5 @@ footer {
   text-align: center;
   margin: 2rem 0;
   font-size: 0.9rem;
-  color: #666;
+  color: #999;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,19 +3,19 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Timezone Comparator</title>
+  <title>Time Code Comparator</title>
   <link rel="stylesheet" href="/static/style.css" />
 </head>
 <body>
   <header>
-    <h1>Timezone Comparator</h1>
-    <p>See every IANA time zone, auto-detect your own, and compare offsets quickly.</p>
+    <h1>Time Code Comparator</h1>
+    <p>Browse common time codes, auto-detect your offset, and compare quickly.</p>
   </header>
 
   <section class="controls">
     <form id="compare-form" method="get" action="/">
       <div class="control">
-        <label for="my_tz">Your timezone</label>
+        <label for="my_tz">Your code</label>
         <select id="my_tz" name="my_tz">
           {% for z in zones %}
             <option value="{{ z }}" {% if z == my_tz %}selected{% endif %}>{{ z }}</option>
@@ -37,7 +37,7 @@
         <button type="submit">Compare</button>
       </div>
     </form>
-    <small class="hint">Tip: Your browser's time zone will auto-fill on load; you can still pick any zone.</small>
+    <small class="hint">Tip: Your browser's offset auto-fills on load; you can still pick any code.</small>
   </section>
 
   <section class="result">
@@ -81,8 +81,8 @@
   </section>
 
   <section class="table-section">
-    <h2>All time zones</h2>
-    <input id="search" type="search" placeholder="Search zones or codes (e.g., UTC, GMT, Europe/)" />
+    <h2>All time codes</h2>
+    <input id="search" type="search" placeholder="Search codes (e.g., UTC+02:00, CET)" />
     <table class="table" id="zones-table">
       <thead>
         <tr>
@@ -104,7 +104,7 @@
   </section>
 
   <footer>
-    <p>Built with Flask &amp; zoneinfo. IANA data via system tzdb/tzdata.</p>
+    <p>Built with Flask using fixed UTC offsets.</p>
   </footer>
 
   <script src="/static/app.js"></script>


### PR DESCRIPTION
## Summary
- Replace country-based zones with fixed UTC codes and common abbreviations
- Auto-detect browser offset and handle comparisons via time codes
- Apply a dark theme and update copy for a modern look

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689eed964f9c8328995a54c55306f6b6