### PR TITLE
Use time codes and dark theme

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,14 +1,14 @@
-// Auto-detect browser timezone and set the "Your timezone" dropdown on first load.
+// Auto-detect browser UTC offset and set the "Your timezone" dropdown on first load.
 (function initAutoDetect() {
   try {
-    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const offsetHours = Math.round(-new Date().getTimezoneOffset() / 60);
+    const sign = offsetHours >= 0 ? '+' : '-';
+    const detected = `UTC${offsetHours === 0 ? '' : sign + Math.abs(offsetHours)}`;
     const url = new URL(window.location.href);
-    if (!url.searchParams.get('my_tz') && detected) {
-      // Only redirect once; add my_tz while preserving other params
+    if (!url.searchParams.get('my_tz')) {
       url.searchParams.set('my_tz', detected);
       if (!url.searchParams.get('other_tz')) {
-        // default to UTC if user is already UTC, else compare with UTC for clarity
-        url.searchParams.set('other_tz', detected === 'Etc/UTC' ? 'Europe/Stockholm' : 'Etc/UTC');
+        url.searchParams.set('other_tz', detected === 'UTC' ? 'UTC+1' : 'UTC');
       }
       window.location.replace(url.toString());
     }

--- a/static/style.css
+++ b/static/style.css
@@ -1,15 +1,16 @@
 body {
-  font-family: Arial, sans-serif;
-  background: #f5f7fa;
-  color: #333;
+  font-family: system-ui, sans-serif;
+  background: #121212;
+  color: #eee;
   margin: 0;
 }
 
 header {
-  background: #004d99;
-  color: #fff;
+  background: #1f1f1f;
+  color: #eee;
   padding: 1rem;
   text-align: center;
+  border-bottom: 1px solid #333;
 }
 
 .controls, .result, .table-section {
@@ -27,6 +28,17 @@ header {
   gap: 0.5rem;
 }
 
+select, button {
+  background: #1f1f1f;
+  color: #eee;
+  border: 1px solid #333;
+  padding: 0.5rem;
+}
+
+button:hover {
+  background: #333;
+}
+
 .cards {
   display: flex;
   justify-content: center;
@@ -36,10 +48,10 @@ header {
 }
 
 .card {
-  background: #fff;
+  background: #1e1e1e;
   padding: 1rem;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.5);
 }
 
 .card.arrow {
@@ -54,13 +66,17 @@ header {
 }
 
 .table th, .table td {
-  border: 1px solid #ddd;
+  border: 1px solid #333;
   padding: 0.5rem;
   text-align: left;
 }
 
+.table th {
+  background: #1f1f1f;
+}
+
 .tz-abbr {
-  color: #666;
+  color: #aaa;
   font-size: 0.8em;
   margin-left: 0.25rem;
 }
@@ -69,6 +85,9 @@ header {
   width: 100%;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  background: #1f1f1f;
+  color: #eee;
+  border: 1px solid #333;
 }
 
 .delta {
@@ -81,5 +100,5 @@ footer {
   text-align: center;
   margin: 2rem 0;
   font-size: 0.9rem;
-  color: #666;
+  color: #aaa;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <h1>Timezone Comparator</h1>
-    <p>See every IANA time zone, auto-detect your own, and compare offsets quickly.</p>
+    <p>Compare simple UTC offsets and common time codes.</p>
   </header>
 
   <section class="controls">
@@ -37,7 +37,7 @@
         <button type="submit">Compare</button>
       </div>
     </form>
-    <small class="hint">Tip: Your browser's time zone will auto-fill on load; you can still pick any zone.</small>
+    <small class="hint">Tip: Your browser's time code will auto-fill on load; you can still pick any code.</small>
   </section>
 
   <section class="result">
@@ -81,8 +81,8 @@
   </section>
 
   <section class="table-section">
-    <h2>All time zones</h2>
-    <input id="search" type="search" placeholder="Search zones or codes (e.g., UTC, GMT, Europe/)" />
+    <h2>All time codes</h2>
+    <input id="search" type="search" placeholder="Search codes (e.g., UTC, UTC+1, CET)" />
     <table class="table" id="zones-table">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- Replace country-based time zones with fixed UTC/GMT codes and support CET/CEST
- Modernize UI with dark theme and updated text
- Detect browser UTC offset and swap/comparison based on codes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689eed964f9c8328995a54c55306f6b6