### PR TITLE
Add reactive time zone comparison

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,21 +1,77 @@
-// Auto-detect browser offset and set the dropdown on first load.
-(function initAutoDetect() {
-  try {
-    const url = new URL(window.location.href);
-    if (!url.searchParams.get('my_tz')) {
-      const offset = -new Date().getTimezoneOffset(); // minutes east of UTC
+// Reactive time zone comparison and utilities
+(function () {
+  const mySel = document.getElementById('my_tz');
+  const otherSel = document.getElementById('other_tz');
+  const timeInput = document.getElementById('base_time');
+  const compareBtn = document.getElementById('compare');
+  const swapBtn = document.getElementById('swap');
+
+  function pad(n) {
+    return String(n).padStart(2, '0');
+  }
+
+  function currentDate() {
+    const d = new Date();
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+
+  function update() {
+    if (!mySel || !otherSel || !timeInput) return;
+    const my = mySel.value;
+    const other = otherSel.value;
+    const t = timeInput.value || '00:00';
+    const time = `${currentDate()}T${t}`;
+    fetch(
+      `/api/compare?my_tz=${encodeURIComponent(my)}&other_tz=${encodeURIComponent(
+        other
+      )}&time=${encodeURIComponent(time)}`
+    )
+      .then((r) => r.json())
+      .then((data) => {
+        document.getElementById('my_tz_label').textContent = my;
+        document.getElementById('other_tz_label').textContent = other;
+        document.getElementById('my_time').textContent = data.my_time;
+        document.getElementById('other_time').textContent = data.other_time;
+        document.getElementById('my_offset').textContent = `UTC ${data.my_offset}`;
+        document.getElementById('other_offset').textContent = `UTC ${data.other_offset}`;
+        document.getElementById('diff_text').textContent = `${data.description} (${data.pretty})`;
+      });
+  }
+
+  // Auto-detect browser offset and set the dropdown
+  (function autoDetect() {
+    try {
+      const offset = -new Date().getTimezoneOffset();
       const sign = offset >= 0 ? '+' : '-';
       const abs = Math.abs(offset);
-      const h = String(Math.floor(abs / 60)).padStart(2, '0');
-      const m = String(abs % 60).padStart(2, '0');
+      const h = pad(Math.floor(abs / 60));
+      const m = pad(abs % 60);
       const code = offset === 0 ? 'UTC' : `UTC${sign}${h}:${m}`;
-      url.searchParams.set('my_tz', code);
-      if (!url.searchParams.get('other_tz')) {
-        url.searchParams.set('other_tz', code === 'UTC' ? 'UTC+01:00' : 'UTC');
-      }
-      window.location.replace(url.toString());
+      if (mySel) mySel.value = code;
+    } catch (e) {
+      /* ignore */
     }
-  } catch (e) { /* ignore */ }
+  })();
+
+  if (mySel) mySel.addEventListener('change', update);
+  if (otherSel) otherSel.addEventListener('change', update);
+  if (timeInput) timeInput.addEventListener('input', update);
+  if (compareBtn) compareBtn.addEventListener('click', update);
+  if (swapBtn)
+    swapBtn.addEventListener('click', () => {
+      if (!mySel || !otherSel) return;
+      const tmp = mySel.value;
+      mySel.value = otherSel.value;
+      otherSel.value = tmp;
+      update();
+    });
+
+  // set default time to now and run initial update
+  if (timeInput && !timeInput.value) {
+    const d = new Date();
+    timeInput.value = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+  update();
 })();
 
 // Client-side filter for the big time zone table
@@ -32,19 +88,3 @@
   });
 })();
 
-// Swap selected time zones and submit the form
-(function swapZones() {
-  const btn = document.getElementById('swap');
-  const form = document.getElementById('compare-form');
-  if (!btn || !form) return;
-  btn.addEventListener('click', () => {
-    const a = document.getElementById('my_tz');
-    const b = document.getElementById('other_tz');
-    if (a && b) {
-      const tmp = a.value;
-      a.value = b.value;
-      b.value = tmp;
-      form.submit();
-    }
-  });
-})();

--- a/static/style.css
+++ b/static/style.css
@@ -25,6 +25,7 @@ header {
 .control.buttons {
   display: flex;
   gap: 0.5rem;
+  justify-content: center;
 }
 
 #compare-form {

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
   </header>
 
   <section class="controls">
-    <form id="compare-form" method="get" action="/">
+    <form id="compare-form">
       <div class="control">
         <label for="my_tz">Your time code</label>
         <select id="my_tz" name="my_tz">
@@ -32,9 +32,14 @@
         </select>
       </div>
 
+      <div class="control">
+        <label for="base_time">Time</label>
+        <input type="time" id="base_time" name="base_time" value="{{ diff.a.strftime('%H:%M') }}" />
+      </div>
+
       <div class="control buttons">
         <button type="button" id="swap">Swap</button>
-        <button type="submit">Compare</button>
+        <button type="button" id="compare">Compare</button>
       </div>
     </form>
     <small class="hint">Tip: Your browser's offset auto-fills on load; you can still pick any code.</small>
@@ -44,18 +49,18 @@
     <h2>Now</h2>
     <div class="cards">
       <div class="card">
-        <h3>{{ my_tz }}</h3>
-        <p class="time">{{ diff.a.strftime('%Y-%m-%d %H:%M') }}</p>
-        <p class="offset">UTC {{ diff.a.strftime('%z')[:3] }}:{{ diff.a.strftime('%z')[3:5] }}</p>
+        <h3 id="my_tz_label">{{ my_tz }}</h3>
+        <p class="time" id="my_time">{{ diff.a.strftime('%Y-%m-%d %H:%M') }}</p>
+        <p class="offset" id="my_offset">UTC {{ diff.a.strftime('%z')[:3] }}:{{ diff.a.strftime('%z')[3:5] }}</p>
       </div>
       <div class="card arrow">→</div>
       <div class="card">
-        <h3>{{ other_tz }}</h3>
-        <p class="time">{{ diff.b.strftime('%Y-%m-%d %H:%M') }}</p>
-        <p class="offset">UTC {{ diff.b.strftime('%z')[:3] }}:{{ diff.b.strftime('%z')[3:5] }}</p>
+        <h3 id="other_tz_label">{{ other_tz }}</h3>
+        <p class="time" id="other_time">{{ diff.b.strftime('%Y-%m-%d %H:%M') }}</p>
+        <p class="offset" id="other_offset">UTC {{ diff.b.strftime('%z')[:3] }}:{{ diff.b.strftime('%z')[3:5] }}</p>
       </div>
     </div>
-    <p class="delta">{{ diff.description }} ({{ diff.pretty }})</p>
+    <p class="delta" id="diff_text">{{ diff.description }} ({{ diff.pretty }})</p>
   </section>
 
   <section class="table-section">


### PR DESCRIPTION
## Summary
- Add JSON endpoint to convert times between zones
- Make UI reactive with time input and auto-detected zone
- Center swap/compare buttons and update results dynamically

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ef3442ec08328a2630119e8ed3fbe